### PR TITLE
Fixes #44963, adds force and flag checks for items attacking brains

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -118,7 +118,10 @@
 	if(brainmob) //if we aren't trying to heal the brain, pass the attack onto the brainmob.
 		O.attack(brainmob, user) //Oh noooeeeee
 
-	damaged_brain = TRUE //brain was attacked, they're pretty fragile.
+        if((O.force == 0) || (O.item_flags & NOBLUDGEON))
+            return // it's okay, we're saved
+
+	    damaged_brain = TRUE //brain was attacked, they're pretty fragile.
 
 /obj/item/organ/brain/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
Adds force and flag checks for items attacking brains to prevent accidental or ridiculous brain damage via straw/pen/whatever
Fixes https://github.com/tgstation/tgstation/issues/44963